### PR TITLE
Fix submodule links in web UI

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,40 +1,40 @@
 [submodule "tools"]
 	path = tools
-	url = ../hope-tools.git
+	url = https://github.com/draperlaboratory/hope-tools.git
 	branch = master
 [submodule "riscv-gnu-toolchain"]
 	path = riscv-gnu-toolchain
-	url = ../hope-riscv-gnu-toolchain.git
+	url = https://github.com/draperlaboratory/hope-riscv-gnu-toolchain.git
 	branch = master
 [submodule "policies"]
 	path = policies
-	url = ../hope-policies.git
+	url = https://github.com/draperlaboratory/hope-policies.git
 	branch = master
 [submodule "FreeRTOS"]
 	path = FreeRTOS
-	url = ../hope-FreeRTOS.git
+	url = https://github.com/draperlaboratory/hope-FreeRTOS.git
 	branch = master
 [submodule "policy-tool"]
 	path = policy-tool
-	url = ../hope-policy-tool.git
+	url = https://github.com/draperlaboratory/hope-policy-tool.git
 	branch = master
 [submodule "policy-engine"]
 	path = policy-engine
-	url = ../hope-policy-engine.git
+	url = https://github.com/draperlaboratory/hope-policy-engine.git
 	branch = master
 [submodule "freedom-e-sdk"]
 	path = freedom-e-sdk
-	url = ../hope-freedom-e-sdk.git
+	url = https://github.com/draperlaboratory/hope-freedom-e-sdk.git
 	branch = master
 [submodule "riscv-newlib"]
 	path = riscv-newlib
-	url = ../hope-riscv-newlib.git
+	url = https://github.com/draperlaboratory/hope-riscv-newlib.git
 	branch = master
 [submodule "llvm-project"]
-       path = llvm-project
-       url = ../hope-llvm-project.git
-       branch = master
+	path = llvm-project
+	url = https://github.com/draperlaboratory/hope-llvm-project.git
+	branch = master
 [submodule "qemu"]
 	path = qemu
-	url = ../hope-qemu.git
+	url = https://github.com/draperlaboratory/hope-qemu.git
 	branch = master


### PR DESCRIPTION
This fixes the submodule links when browsing `hope-src` on GitHub. This means it's possible to click through to submodules.