### PR TITLE
Update Jenkins to use Vivado 2019.2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -223,13 +223,13 @@ pipeline {
                     echo "Running tests"
                     sh """
                             export ISP_PREFIX=${ispPrefix}
-                            export PATH=${ispPrefix}bin:${env.JENKINS_HOME}/.local/bin:${env.PATH}:/opt/Xilinx/Vivado/2019.1/bin
+                            export PATH=${ispPrefix}bin:${env.JENKINS_HOME}/.local/bin:${env.PATH}:/opt/Xilinx/Vivado/2019.2/bin
                             make -C policies/policy_tests clean-tests clean-policies
                         """
                     catchError(buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
                         sh """
                             export ISP_PREFIX=${ispPrefix}
-                            export PATH=${ispPrefix}bin:${env.JENKINS_HOME}/.local/bin:${env.PATH}:/opt/Xilinx/Vivado/2019.1/bin
+                            export PATH=${ispPrefix}bin:${env.JENKINS_HOME}/.local/bin:${env.PATH}:/opt/Xilinx/Vivado/2019.2/bin
                             make -C policies/policy_tests run-tests JOBS=1 TESTS=hello_works_1,cfi/jump_data_fails_1 CONFIG=bare-vcu118
                             """
                     }
@@ -237,7 +237,7 @@ pipeline {
                     catchError(buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
                         sh """
                             export ISP_PREFIX=${ispPrefix}
-                            export PATH=${ispPrefix}/bin:${env.JENKINS_HOME}/.local/bin:${env.PATH}:/opt/Xilinx/Vivado/2019.1/bin
+                            export PATH=${ispPrefix}/bin:${env.JENKINS_HOME}/.local/bin:${env.PATH}:/opt/Xilinx/Vivado/2019.2/bin
                             export BITSTREAM=${ispPrefix}/vcu118/bitstreams/soc_chisel_pipe_p2.bit
                             make -C policies/policy_tests run-tests JOBS=1 TESTS=hello_works_1,cfi/jump_data_fails_1 CONFIG=bare64-vcu118
                             """
@@ -246,7 +246,7 @@ pipeline {
                     catchError(buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
                         sh """
                             export ISP_PREFIX=${ispPrefix}
-                            export PATH=${ispPrefix}bin:${env.JENKINS_HOME}/.local/bin:${env.PATH}:/opt/Xilinx/Vivado/2019.1/bin
+                            export PATH=${ispPrefix}bin:${env.JENKINS_HOME}/.local/bin:${env.PATH}:/opt/Xilinx/Vivado/2019.2/bin
                             make -C policies/policy_tests run-tests JOBS=1 TESTS=hello_works_1,cfi/jump_data_fails_1  GPOLICIES= POLICIES=rwx,none,stack,heap,cfi CONFIG=frtos-vcu118
                             """
                     }
@@ -254,7 +254,7 @@ pipeline {
                     catchError(buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
                         sh """
                             export ISP_PREFIX=${ispPrefix}
-                            export PATH=${ispPrefix}/bin:${env.JENKINS_HOME}/.local/bin:${env.PATH}:/opt/Xilinx/Vivado/2019.1/bin
+                            export PATH=${ispPrefix}/bin:${env.JENKINS_HOME}/.local/bin:${env.PATH}:/opt/Xilinx/Vivado/2019.2/bin
                             export BITSTREAM=${ispPrefix}/vcu118/bitstreams/soc_chisel_pipe_p2.bit
                             make -C policies/policy_tests run-tests JOBS=1 TESTS=hello_works_1  GPOLICIES= POLICIES=rwx COMPOSITE=none CONFIG=frtos64-vcu118
                             """


### PR DESCRIPTION
This updates the version of vivado that jenkins is using. I expect this to fix the FPGA tests in CI.