### PR TITLE
Jenkins: Use node labels

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,6 +11,7 @@
  */
 
 String periodic_build = env.BRANCH_NAME == "master" ? "@midnight" : ""
+String agent_string = env.BRANCH_NAME == "master" ? "'vcu118 && ubuntu18.04'" : "'ubuntu18.04'"
 
 def getGitModuleSha(String module) {
     return sh(script: """cd ${env.WORKSPACE}
@@ -38,7 +39,7 @@ def changedModules
 def shas
 def ispPrefix
 pipeline {
-    agent any
+    agent { label agent_string }
     triggers { cron(periodic_build) }
     options {
         disableConcurrentBuilds()


### PR DESCRIPTION
Allow dynamically choosing what Jenkins agents can run the pipeline based on the branch name.

